### PR TITLE
use pypi api token instead of username and password auth when publis…

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -19,6 +19,6 @@ jobs:
       run: python setup.py sdist bdist_wheel
     - name: Publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: twine upload dist/*


### PR DESCRIPTION
  * Use pypi api token instead of username and password auth when publishing the package to pypi, since username and password is deprecated