### PR TITLE
ci: add installation test workflow

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,31 @@
+name: Installation Test
+
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
+    branches: [master]
+
+jobs:
+  install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Ensure build tools
+        run: |
+          python -m pip install --upgrade pip setuptools
+      - name: Install package via setup.py
+        run: |
+          python setup.py install
+      - name: Verify installation
+        run: |
+          python -c "import chpass"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "sqlalchemy==2.0.25",
-        "pattern_singleton==1.2.0",
+        "pattern-singleton==1.2.0",
         "pandas==2.2.0"
     ],
     python_requires=">=3",


### PR DESCRIPTION
## Summary
- add CI job to verify install via setup.py on Windows, macOS, and Linux
- ensure setuptools is installed before running setup.py
- rely on setup.py to pull in dependencies automatically
- fix dependency name for pattern-singleton so setup.py installs required package
- run installation workflow on pull_request to master for validation

## Testing
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a5f1301083328b4ab27bb10fd2d8