### PR TITLE
Add profile flag to customize Chrome paths

### DIFF
--- a/chpass/__main__.py
+++ b/chpass/__main__.py
@@ -23,13 +23,13 @@ def create_file_adapter(file_adapter_type: str) -> file_adapter_interface:
     return object_factory.create(file_adapter_type, exception=FileAdapterNotSupportedException)
 
 
-def create_chrome_db_adapter(protocol: str, os_user: str) -> ChromeDBAdapter:
+def create_chrome_db_adapter(protocol: str, os_user: str, profile: str) -> ChromeDBAdapter:
     logins_db_connection = DBConnection()
     history_db_connection = DBConnection()
     top_sites_db_connection = DBConnection()
-    logins_db_connection.connect(protocol, get_chrome_logins_path(os_user))
-    history_db_connection.connect(protocol, get_chrome_history_path(os_user))
-    top_sites_db_connection.connect(protocol, get_chrome_top_sites_path(os_user))
+    logins_db_connection.connect(protocol, get_chrome_logins_path(os_user, profile))
+    history_db_connection.connect(protocol, get_chrome_history_path(os_user, profile))
+    top_sites_db_connection.connect(protocol, get_chrome_top_sites_path(os_user, profile))
     logins_db_adapter = LoginsDBAdapter(logins_db_connection)
     history_db_adapter = HistoryDBAdapter(history_db_connection)
     top_sites_db_adapter = TopSitesDBAdapter(top_sites_db_connection)
@@ -43,10 +43,10 @@ def start(args=None) -> None:
         args = parse_args(sys.argv[1:])
     file_adapter = create_file_adapter(args.file_adapter)
     output_file_paths = OUTPUT_FILE_PATHS[args.file_adapter]
-    chrome_db_adapter = create_chrome_db_adapter(DB_PROTOCOL, args.user)
+    chrome_db_adapter = create_chrome_db_adapter(DB_PROTOCOL, args.user, args.profile)
     mode_actions = {
         "export": lambda: export_chrome_data(chrome_db_adapter, args.destination_folder, file_adapter,
-                                             output_file_paths, args.user, args.export_kind),
+                                             output_file_paths, args.user, args.export_kind, args.profile),
         "import": lambda: import_chrome_passwords(chrome_db_adapter, args.from_file, file_adapter)
     }
     mode_actions[args.mode]()

--- a/chpass/cli.py
+++ b/chpass/cli.py
@@ -3,7 +3,8 @@ import getpass
 
 from chpass.config import (
     DEFAULT_EXPORT_DESTINATION_FOLDER,
-    DEFAULT_FILE_ADAPTER
+    DEFAULT_FILE_ADAPTER,
+    DEFAULT_CHROME_PROFILE
 )
 
 
@@ -50,6 +51,7 @@ def create_arg_parser() -> argparse.ArgumentParser:
     create_export_parser(subparsers)
     parser.add_argument("-u", "--user", dest="user", type=str, default=getpass.getuser())
     parser.add_argument("-i", "--file-adapter", dest="file_adapter", type=str, default=DEFAULT_FILE_ADAPTER)
+    parser.add_argument("-p", "--profile", dest="profile", type=str, default=DEFAULT_CHROME_PROFILE)
     return parser
 
 

--- a/chpass/config.py
+++ b/chpass/config.py
@@ -7,10 +7,11 @@ CHROME_FOLDER_OS_PATHS = {
     "darwin": "Library/Application Support/Google/Chrome"
 }
 
-LOGINS_DB_FILE_PATH = os.path.join("Default", "Login Data")
-HISTORY_DB_FILE_PATH = os.path.join("Default", "History")
-TOP_SITES_DB_FILE_PATH = os.path.join("Default", "Top Sites")
-GOOGLE_PICTURE_FILE_PATH = os.path.join("Default", "Google Profile Picture.png")
+DEFAULT_CHROME_PROFILE = "Default"
+LOGINS_DB_FILE_NAME = "Login Data"
+HISTORY_DB_FILE_NAME = "History"
+TOP_SITES_DB_FILE_NAME = "Top Sites"
+GOOGLE_PICTURE_FILE_NAME = "Google Profile Picture.png"
 
 DEFAULT_EXPORT_DESTINATION_FOLDER = "dist"
 OUTPUT_FILE_PATHS = {

--- a/chpass/services/chrome.py
+++ b/chpass/services/chrome.py
@@ -5,7 +5,7 @@ from typing import List, Callable
 
 from chpass.dal.chrome_db_adapter import ChromeDBAdapter
 from chpass.core.interfaces import file_adapter_interface
-from chpass.config import PASSWORDS_FILE_BYTES_COLUMNS, CREDENTIALS_ALREADY_EXIST_MESSAGE
+from chpass.config import PASSWORDS_FILE_BYTES_COLUMNS, CREDENTIALS_ALREADY_EXIST_MESSAGE, DEFAULT_CHROME_PROFILE
 from chpass.services.path import get_chrome_profile_picture_path
 
 
@@ -18,14 +18,15 @@ def generic_export(
     file_adapter.write(data, f"{destination_folder}/{filename}")
 
 
-def export_profile_picture(destination_path: str, user: str = getpass.getuser()) -> None:
+def export_profile_picture(destination_path: str, user: str = getpass.getuser(),
+                           profile: str = DEFAULT_CHROME_PROFILE) -> None:
     """Exports google profile picture
     :param destination_path: Destination path to export the picture
     :param user: Chrome user
     :return: None
     :rtype: None
     """
-    source_path = get_chrome_profile_picture_path(user)
+    source_path = get_chrome_profile_picture_path(user, profile)
     copyfile(source_path, destination_path)
 
 
@@ -103,7 +104,8 @@ def export_chrome_data(
         file_adapter: file_adapter_interface,
         output_file_paths: dict,
         user: str = getpass.getuser(),
-        export_kind: str = None) -> None:
+        export_kind: str = None,
+        profile: str = DEFAULT_CHROME_PROFILE) -> None:
     """Exports chrome data to a file
     :param chrome_db_adapter: Adapter for the chrome db
     :param destination_folder: Destination folder path to save file in
@@ -111,6 +113,7 @@ def export_chrome_data(
     :param output_file_paths: Dictionary that maps between data type and its destination file path
     :param user: Chrome user
     :param export_kind: Specific data type export instead of export all the data
+    :param profile: Chrome profile folder name
     :return: None
     :rtype: None
     """
@@ -125,7 +128,8 @@ def export_chrome_data(
                                               output_file_paths["downloads"]),
         "top_sites": lambda: export_top_sites(chrome_db_adapter, file_adapter, destination_folder,
                                               output_file_paths["top_sites"]),
-        "profile_pic": lambda: export_profile_picture(f"{destination_folder}/{output_file_paths['profile_picture']}", user)
+        "profile_pic": lambda: export_profile_picture(
+            f"{destination_folder}/{output_file_paths['profile_picture']}", user, profile)
     }
     if export_kind:
         export_functions[export_kind]()

--- a/chpass/services/path.py
+++ b/chpass/services/path.py
@@ -3,11 +3,12 @@ import os
 import sys
 
 from chpass.config import (
-    HISTORY_DB_FILE_PATH,
-    LOGINS_DB_FILE_PATH,
-    TOP_SITES_DB_FILE_PATH,
-    GOOGLE_PICTURE_FILE_PATH,
-    CHROME_FOLDER_OS_PATHS
+    HISTORY_DB_FILE_NAME,
+    LOGINS_DB_FILE_NAME,
+    TOP_SITES_DB_FILE_NAME,
+    GOOGLE_PICTURE_FILE_NAME,
+    CHROME_FOLDER_OS_PATHS,
+    DEFAULT_CHROME_PROFILE
 )
 from chpass.exceptions.chrome_not_installed_exception import ChromeNotInstalledException
 from chpass.exceptions.operating_system_not_supported import OperatingSystemNotSupported
@@ -43,17 +44,17 @@ def get_chrome_user_folder(user: str = getpass.getuser(), platform=sys.platform)
     return chrome_user_folder
 
 
-def get_chrome_history_path(user: str = getpass.getuser()) -> str:
-    return os.path.join(get_chrome_user_folder(user), HISTORY_DB_FILE_PATH)
+def get_chrome_history_path(user: str = getpass.getuser(), profile: str = DEFAULT_CHROME_PROFILE) -> str:
+    return os.path.join(get_chrome_user_folder(user), profile, HISTORY_DB_FILE_NAME)
 
 
-def get_chrome_logins_path(user: str = getpass.getuser()) -> str:
-    return os.path.join(get_chrome_user_folder(user), LOGINS_DB_FILE_PATH)
+def get_chrome_logins_path(user: str = getpass.getuser(), profile: str = DEFAULT_CHROME_PROFILE) -> str:
+    return os.path.join(get_chrome_user_folder(user), profile, LOGINS_DB_FILE_NAME)
 
 
-def get_chrome_top_sites_path(user: str = getpass.getuser()) -> str:
-    return os.path.join(get_chrome_user_folder(user), TOP_SITES_DB_FILE_PATH)
+def get_chrome_top_sites_path(user: str = getpass.getuser(), profile: str = DEFAULT_CHROME_PROFILE) -> str:
+    return os.path.join(get_chrome_user_folder(user), profile, TOP_SITES_DB_FILE_NAME)
 
 
-def get_chrome_profile_picture_path(user: str = getpass.getuser()) -> str:
-    return os.path.join(get_chrome_user_folder(user), GOOGLE_PICTURE_FILE_PATH)
+def get_chrome_profile_picture_path(user: str = getpass.getuser(), profile: str = DEFAULT_CHROME_PROFILE) -> str:
+    return os.path.join(get_chrome_user_folder(user), profile, GOOGLE_PICTURE_FILE_NAME)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import getpass
 import pytest
 
 from chpass.__main__ import create_chrome_db_adapter
-from chpass.config import DB_PROTOCOL
+from chpass.config import DB_PROTOCOL, DEFAULT_CHROME_PROFILE
 from chpass.dal import chrome_db_adapter
 
 
@@ -19,7 +19,7 @@ def disconnected_user() -> str:
 
 @pytest.fixture(scope="session")
 def chrome_db_adapter(request, connected_user) -> chrome_db_adapter:
-    chrome_db_adapter = create_chrome_db_adapter(DB_PROTOCOL, connected_user)
+    chrome_db_adapter = create_chrome_db_adapter(DB_PROTOCOL, connected_user, DEFAULT_CHROME_PROFILE)
 
     def fin():
         chrome_db_adapter.close()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,7 +1,7 @@
 import pytest
 
 from chpass.cli import parse_args
-from chpass.config import DEFAULT_EXPORT_DESTINATION_FOLDER, DEFAULT_FILE_ADAPTER
+from chpass.config import DEFAULT_EXPORT_DESTINATION_FOLDER, DEFAULT_FILE_ADAPTER, DEFAULT_CHROME_PROFILE
 
 
 @pytest.fixture(scope="module")
@@ -25,6 +25,7 @@ def test_default_export(export_mode, connected_user):
     assert args.user == connected_user
     assert args.destination_folder == DEFAULT_EXPORT_DESTINATION_FOLDER
     assert args.file_adapter == DEFAULT_FILE_ADAPTER
+    assert args.profile == DEFAULT_CHROME_PROFILE
     assert not hasattr(args, "from_file")
 
 
@@ -35,6 +36,7 @@ def test_default_import(import_mode, connected_user, from_file):
     assert not hasattr(args, "destination_folder")
     assert args.file_adapter == "csv"
     assert args.from_file == from_file
+    assert args.profile == DEFAULT_CHROME_PROFILE
 
 
 def test_user_flag_export(export_mode, connected_user):
@@ -42,6 +44,7 @@ def test_user_flag_export(export_mode, connected_user):
     args = parse_args(["-u", user, export_mode])
     assert args.mode == export_mode
     assert args.user == user
+    assert args.profile == DEFAULT_CHROME_PROFILE
 
 
 def test_user_flag_import(import_mode, from_file, connected_user):
@@ -49,6 +52,7 @@ def test_user_flag_import(import_mode, from_file, connected_user):
     args = parse_args(["-u", user, import_mode, "-f", from_file])
     assert args.mode == import_mode
     assert args.user == user
+    assert args.profile == DEFAULT_CHROME_PROFILE
 
 
 def test_file_adapter_flag_export(export_mode):
@@ -56,6 +60,7 @@ def test_file_adapter_flag_export(export_mode):
     args = parse_args(["-i", file_adapter, export_mode])
     assert args.mode == export_mode
     assert args.file_adapter == file_adapter
+    assert args.profile == DEFAULT_CHROME_PROFILE
 
 
 @pytest.fixture
@@ -67,6 +72,7 @@ def test_file_adapter_flag_import(import_mode, correct_file_adapter, from_file):
     args = parse_args(["-i", correct_file_adapter, import_mode, "-f", from_file])
     assert args.mode == import_mode
     assert correct_file_adapter == correct_file_adapter
+    assert args.profile == DEFAULT_CHROME_PROFILE
 
 
 @pytest.fixture
@@ -78,3 +84,11 @@ def test_export_destination_folder_flag(export_mode, correct_destination_folder)
     args = parse_args([export_mode, "-d", correct_destination_folder])
     assert args.mode == export_mode
     assert args.destination_folder == correct_destination_folder
+    assert args.profile == DEFAULT_CHROME_PROFILE
+
+
+def test_profile_flag(export_mode):
+    profile = "Profile 1"
+    args = parse_args(["-p", profile, export_mode])
+    assert args.mode == export_mode
+    assert args.profile == profile


### PR DESCRIPTION
## Summary
- allow choosing a Chrome profile via `-p/--profile`
- build history, logins, top sites, and profile picture paths using selected profile
- propagate profile through CLI, path utilities and export logic

## Testing
- `pytest tests/unit/test_cli.py`
- `pytest` *(fails: ChromeNotInstalledException and other errors; environment lacks Chrome databases)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ca127e388332ac2ed99ea1af2e1c