### PR TITLE
Replace argparse with Click

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ exceptiongroup = ">=1.2.2"
 pattern-singleton = ">=1.2.0"
 pandas = "==2.2.0"
 sqlalchemy = "==2.0.31"
+click = ">=8.1.7"
 
 [scripts]
 lint = "pylint --rcfile=.pylintrc chpass"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setuptools.setup(
     install_requires=[
         "pattern-singleton==1.2.0",
         "sqlalchemy==2.0.31",
-        "pandas==2.2.0"
+        "pandas==2.2.0",
+        "click>=8.1.7"
     ],
     python_requires=">=3",
     entry_points={

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,7 +1,11 @@
 import pytest
 
 from chpass.cli import parse_args
-from chpass.config import DEFAULT_EXPORT_DESTINATION_FOLDER, DEFAULT_FILE_ADAPTER, DEFAULT_CHROME_PROFILE
+from chpass.config import (
+    DEFAULT_CHROME_PROFILE,
+    DEFAULT_EXPORT_DESTINATION_FOLDER,
+    DEFAULT_FILE_ADAPTER,
+)
 
 
 @pytest.fixture(scope="module")
@@ -17,11 +21,6 @@ def import_mode() -> str:
 @pytest.fixture(scope="module")
 def from_file() -> str:
     return "passwords.csv"
-
-
-@pytest.fixture(scope="module")
-def profiles_mode() -> str:
-    return "list-profiles"
 
 
 def test_default_export(export_mode, connected_user):
@@ -97,3 +96,22 @@ def test_profile_flag(export_mode):
     args = parse_args(["-p", profile, export_mode])
     assert args.mode == export_mode
     assert args.profile == profile
+
+
+def test_list_profiles(connected_user):
+    args = parse_args(["list-profiles"])
+    assert args.mode == "list-profiles"
+    assert args.user == connected_user
+    assert args.profile == DEFAULT_CHROME_PROFILE
+
+
+@pytest.mark.parametrize(
+    "export_kind",
+    ["passwords", "history", "downloads", "top_sites", "profile_pic"],
+)
+def test_export_subcommands(export_kind):
+    args = parse_args(["export", export_kind])
+    assert args.mode == "export"
+    assert args.export_kind == export_kind
+    assert args.destination_folder == DEFAULT_EXPORT_DESTINATION_FOLDER
+    assert args.profile == DEFAULT_CHROME_PROFILE


### PR DESCRIPTION
## Summary
- refactor CLI to use Click instead of argparse
- add Click dependency

## Testing
- `pytest tests/unit/test_cli.py`
- `pytest` *(fails: chpass.exceptions.chrome_not_installed_exception)*

------
https://chatgpt.com/codex/tasks/task_e_68a8db43b9ac8332a580a740bb9fd324