### PR TITLE
Handle missing Chrome profiles during data import/export

### DIFF
--- a/chpass/exceptions/chrome_profile_not_found_exception.py
+++ b/chpass/exceptions/chrome_profile_not_found_exception.py
@@ -1,0 +1,15 @@
+
+
+class ChromeProfileNotFoundException(Exception):
+    def __init__(self, profile: str) -> None:
+        self._profile = profile
+        message = f"Chrome profile not found - '{profile}'"
+        super().__init__(message)
+
+    @property
+    def profile(self) -> str:
+        return self._profile
+
+    @profile.setter
+    def profile(self, new_profile: str) -> None:
+        self._profile = new_profile

--- a/chpass/services/path.py
+++ b/chpass/services/path.py
@@ -14,6 +14,7 @@ from chpass.config import (
 from chpass.exceptions.chrome_not_installed_exception import ChromeNotInstalledException
 from chpass.exceptions.operating_system_not_supported import OperatingSystemNotSupported
 from chpass.exceptions.user_not_found_exception import UserNotFoundException
+from chpass.exceptions.chrome_profile_not_found_exception import ChromeProfileNotFoundException
 
 
 def get_home_directory(user: str = getpass.getuser()) -> str:
@@ -45,20 +46,28 @@ def get_chrome_user_folder(user: str = getpass.getuser(), platform=sys.platform)
     return chrome_user_folder
 
 
+def get_chrome_profile_path(user: str = getpass.getuser(), profile: str = DEFAULT_CHROME_PROFILE) -> str:
+    chrome_user_folder = get_chrome_user_folder(user)
+    profile_path = os.path.join(chrome_user_folder, profile)
+    if not os.path.exists(profile_path):
+        raise ChromeProfileNotFoundException(profile)
+    return profile_path
+
+
 def get_chrome_history_path(user: str = getpass.getuser(), profile: str = DEFAULT_CHROME_PROFILE) -> str:
-    return os.path.join(get_chrome_user_folder(user), profile, HISTORY_DB_FILE_NAME)
+    return os.path.join(get_chrome_profile_path(user, profile), HISTORY_DB_FILE_NAME)
 
 
 def get_chrome_logins_path(user: str = getpass.getuser(), profile: str = DEFAULT_CHROME_PROFILE) -> str:
-    return os.path.join(get_chrome_user_folder(user), profile, LOGINS_DB_FILE_NAME)
+    return os.path.join(get_chrome_profile_path(user, profile), LOGINS_DB_FILE_NAME)
 
 
 def get_chrome_top_sites_path(user: str = getpass.getuser(), profile: str = DEFAULT_CHROME_PROFILE) -> str:
-    return os.path.join(get_chrome_user_folder(user), profile, TOP_SITES_DB_FILE_NAME)
+    return os.path.join(get_chrome_profile_path(user, profile), TOP_SITES_DB_FILE_NAME)
 
 
 def get_chrome_profile_picture_path(user: str = getpass.getuser(), profile: str = DEFAULT_CHROME_PROFILE) -> str:
-    return os.path.join(get_chrome_user_folder(user), profile, GOOGLE_PICTURE_FILE_NAME)
+    return os.path.join(get_chrome_profile_path(user, profile), GOOGLE_PICTURE_FILE_NAME)
 
 
 def get_chrome_profiles(user: str = getpass.getuser(), platform: str = sys.platform) -> List[str]:

--- a/tests/integration/test_export_profile_picture.py
+++ b/tests/integration/test_export_profile_picture.py
@@ -1,0 +1,28 @@
+import os
+
+import pytest
+
+from chpass.exceptions.chrome_profile_not_found_exception import ChromeProfileNotFoundException
+from chpass import export_profile_picture
+
+
+@pytest.fixture(scope="module")
+def correct_destination_path() -> str:
+    return "test_profile_picture.jpg"
+
+
+@pytest.fixture
+def profile_not_exist() -> str:
+    return "not_exist"
+
+
+def test_export_profile_picture_profile_not_exist(
+    monkeypatch, tmp_path, correct_destination_path, profile_not_exist
+):
+    monkeypatch.setattr(
+        "chpass.services.path.get_chrome_user_folder", lambda user: str(tmp_path)
+    )
+    with pytest.raises(ChromeProfileNotFoundException):
+        export_profile_picture(correct_destination_path, "user", profile_not_exist)
+    assert not os.path.exists(correct_destination_path)
+

--- a/tests/integration/test_profile_picture.py
+++ b/tests/integration/test_profile_picture.py
@@ -59,5 +59,3 @@ def test_export_profile_picture_invalid_destination_path(invalid_destination_pat
     with pytest.raises(ValueError):
         export_profile_picture( invalid_destination_path, connected_user)
     assert not os.path.exists(invalid_destination_path)
-
-

--- a/tests/integration/test_profile_picture.py
+++ b/tests/integration/test_profile_picture.py
@@ -59,3 +59,5 @@ def test_export_profile_picture_invalid_destination_path(invalid_destination_pat
     with pytest.raises(ValueError):
         export_profile_picture( invalid_destination_path, connected_user)
     assert not os.path.exists(invalid_destination_path)
+
+


### PR DESCRIPTION
## Summary
- Quote missing profile name in `ChromeProfileNotFoundException` message
- Move missing profile export test into `test_export_profile_picture.py`

## Testing
- `pytest tests/integration/test_export_profile_picture.py::test_export_profile_picture_profile_not_exist -q`
- `pytest tests/integration/test_profile_picture.py::test_export_profile_picture -q` *(fails: chrome is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a96ebd145483328fe1458a36d2bd83