### PR TITLE
Add verbose export/import completion messages

### DIFF
--- a/chpass/services/chrome.py
+++ b/chpass/services/chrome.py
@@ -133,9 +133,11 @@ def export_chrome_data(
     }
     if export_kind:
         export_functions[export_kind]()
+        print(f"[+] Exported '{export_kind}' to '{destination_folder}'")
     else:
         for export_func in export_functions.values():
             export_func()
+        print(f"[+] Exported all chrome data to '{destination_folder}'")
 
 
 def filter_existed_logins(chrome_db_adapter: ChromeDBAdapter, logins_to_import: List[dict]) -> list:
@@ -164,6 +166,9 @@ def import_chrome_passwords(chrome_db_adapter: ChromeDBAdapter, source_file_path
     unique_logins_to_import = filter_existed_logins(chrome_db_adapter, logins_to_import)
     for login in unique_logins_to_import:
         chrome_db_adapter.logins_db.logins_table.insert_login(login)
+    print(
+        f"[+] Imported {len(unique_logins_to_import)} credentials from '{source_file_path}'"
+    )
 
 
 def list_profiles(user: str = getpass.getuser()) -> None:

--- a/tests/unit/test_services_messages.py
+++ b/tests/unit/test_services_messages.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+
+from chpass.services.chrome import export_chrome_data, import_chrome_passwords
+
+
+def test_export_passwords_message(tmp_path, capsys):
+    chrome_db_adapter = MagicMock()
+    chrome_db_adapter.logins_db.logins_table.get_all_logins.return_value = []
+    file_adapter = MagicMock()
+    output_file_paths = {
+        "passwords": "passwords.csv",
+        "history": "history.csv",
+        "downloads": "downloads.csv",
+        "top_sites": "top.csv",
+        "profile_picture": "profile.png",
+    }
+    export_chrome_data(chrome_db_adapter, str(tmp_path), file_adapter, output_file_paths, export_kind="passwords")
+    captured = capsys.readouterr()
+    assert "[+] Exported 'passwords' to" in captured.out
+    assert str(tmp_path) in captured.out
+
+
+def test_import_passwords_message(tmp_path, capsys):
+    chrome_db_adapter = MagicMock()
+    chrome_db_adapter.logins_db.logins_table.get_all_logins.return_value = []
+    file_adapter = MagicMock()
+    file_adapter.read.return_value = []
+    source_file = tmp_path / "passwords.csv"
+    source_file.write_text("")
+    import_chrome_passwords(chrome_db_adapter, str(source_file), file_adapter)
+    captured = capsys.readouterr()
+    assert "[+] Imported 0 credentials from" in captured.out
+    assert str(source_file) in captured.out


### PR DESCRIPTION
## Summary
- print success messages after exporting or importing data
- add tests verifying the new messages

## Testing
- `pytest` *(fails: chrome is not installed for the user)*

------
https://chatgpt.com/codex/tasks/task_e_68a97427b3108332b2cdf6122ac90495