### PR TITLE
Use home directory for default export path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ usage: chpass [-h] [-u USER] [-i FILE_ADAPTER] {import,export} ...
 usage: chpass export [-h] [-d DESTINATION_FOLDER] {passwords,history,downloads,top_sites,profile_pic} ...
 ```
 
+If `-d/--destination` is omitted, files are exported to `~/chpass_exports` by default.
+
 ### Import
 
 ```console

--- a/chpass/config.py
+++ b/chpass/config.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 CHROME_FOLDER_OS_PATHS = {
     "win32": r"AppData\Local\Google\Chrome\User Data",
@@ -15,7 +16,9 @@ HISTORY_DB_FILE_NAME = "History"
 TOP_SITES_DB_FILE_NAME = "Top Sites"
 GOOGLE_PICTURE_FILE_NAME = "Google Profile Picture.png"
 
-DEFAULT_EXPORT_DESTINATION_FOLDER = "dist"
+# Default path where exported data will be stored when no destination is
+# provided. The directory is created under the current user's home folder.
+DEFAULT_EXPORT_DESTINATION_FOLDER = Path.home() / "chpass_exports"
 OUTPUT_FILE_PATHS = {
     "csv": {
         "passwords": "passwords.csv",

--- a/tests/integration/test_export_all_data.py
+++ b/tests/integration/test_export_all_data.py
@@ -1,4 +1,5 @@
 import pytest
+from chpass.config import DEFAULT_EXPORT_DESTINATION_FOLDER
 
 
 @pytest.fixture(scope="module")
@@ -12,8 +13,8 @@ def file_adapter_type() -> str:
 
 
 @pytest.fixture(scope="module")
-def destination_folder() -> str:
-    return "dist"
+def destination_folder():
+    return DEFAULT_EXPORT_DESTINATION_FOLDER
 
 
 def test_default_export(export_mode):

--- a/tests/integration/test_import_passwords.py
+++ b/tests/integration/test_import_passwords.py
@@ -1,4 +1,5 @@
 import pytest
+from chpass.config import DEFAULT_EXPORT_DESTINATION_FOLDER
 
 
 @pytest.fixture(scope="module")
@@ -7,8 +8,8 @@ def import_mode() -> str:
 
 
 @pytest.fixture(scope="module")
-def from_file() -> str:
-    return "dist/passwords.csv"
+def from_file():
+    return DEFAULT_EXPORT_DESTINATION_FOLDER / "passwords.csv"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary
- default exports now go to `~/chpass_exports`
- update integration tests to reference new default export location
- document default export directory in README

## Testing
- `python -m pytest`
- `python -m pytest tests/unit/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68a97e6fdb148332966c61b94b444f5c