### PR TITLE
Add basic usage examples

### DIFF
--- a/examples/export_all_data.py
+++ b/examples/export_all_data.py
@@ -1,0 +1,31 @@
+"""Export all Chrome data to a folder using chpass."""
+
+import getpass
+
+from chpass.__main__ import create_chrome_db_adapter, create_file_adapter
+from chpass.config import DB_PROTOCOL, OUTPUT_FILE_PATHS, DEFAULT_CHROME_PROFILE
+from chpass.services.chrome import export_chrome_data
+
+def main() -> None:
+    """Export passwords, history, downloads, top sites and profile picture.
+
+    Data is written for the current user into the "backup" folder using CSV
+    format. Chrome must be closed while this runs.
+    """
+    file_adapter = create_file_adapter("csv")
+    chrome_db_adapter = create_chrome_db_adapter(
+        DB_PROTOCOL, getpass.getuser(), DEFAULT_CHROME_PROFILE
+    )
+    try:
+        export_chrome_data(
+            chrome_db_adapter,
+            "backup",
+            file_adapter,
+            OUTPUT_FILE_PATHS["csv"],
+        )
+    finally:
+        chrome_db_adapter.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/list_profiles.py
+++ b/examples/list_profiles.py
@@ -1,0 +1,12 @@
+"""List the available Chrome profiles for the current user."""
+
+from chpass.services.chrome import list_profiles
+
+
+def main() -> None:
+    """Print available Chrome profiles for the current user."""
+    list_profiles()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script showing how to export all Chrome data to a backup folder
- add script demonstrating listing Chrome profiles
- wrap example scripts in `main` functions for safe import
- update examples to call service functions directly instead of CLI entry point

## Testing
- `pytest` *(fails: ChromeNotInstalledException)*

------
https://chatgpt.com/codex/tasks/task_e_68a97fbe5cec8332a6f826397a44f00f